### PR TITLE
Added ValidationException import into the NewPasswordController

### DIFF
--- a/app/Http/Controllers/Api/NewPasswordController.php
+++ b/app/Http/Controllers/Api/NewPasswordController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Validation\Rules\Password as RulesPassword;
+use Illuminate\Validation\ValidationException;
 
 class NewPasswordController extends Controller
 {


### PR DESCRIPTION
This Pull request entails a bug fix, whereby I imported the "Illuminate\Validation\ValidationException" into the "NewPasswordController" in order to curb any error that might occur when the "throw ValidationException::withMessage()" is called.

Thank you.  